### PR TITLE
Implement audio recording interface

### DIFF
--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -1,6 +1,8 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 
+import Recorder from '@/views/Recorder'
+
 Vue.use(Router)
 
 export default new Router({
@@ -9,6 +11,11 @@ export default new Router({
       path: '/',
       name: 'menu',
       component: require('@/components/Menu').default
+    },
+    {
+      path: '/recorder',
+      name: 'recorder',
+      component: Recorder
     },
     {
       path: '*',

--- a/src/renderer/views/Recorder.vue
+++ b/src/renderer/views/Recorder.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>Recording...</h1>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Recorder'
+}
+</script>
+
+<style>
+
+</style>


### PR DESCRIPTION
Implements #4.

Although the interface is ready, I was unable to get the microphone recording to actually work. Turns out `electron-vue`'s version of `electron` dates back to 2015, so the audio related libraries (internal and external) I've been trying are basically all broken.

I'm afraid we might have to migrate to a separate project that uses a newer version of `electron`, but as far as milestone 1 is concerned, the work is sufficient to demonstrate our idea.