### PR TITLE
Allow renaming of recordings

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "@types/react-dom": "^16.9.9",
     "@types/react-router-dom": "^5.1.6",
     "@types/react-test-renderer": "^16.9.3",
+    "@types/uuid": "^8.3.1",
     "@types/wav": "^1.0.0",
     "@types/webpack-env": "^1.15.2",
     "@typescript-eslint/eslint-plugin": "^4.8.1",

--- a/package.json
+++ b/package.json
@@ -268,6 +268,7 @@
     "react-router-dom": "^5.2.0",
     "regenerator-runtime": "^0.13.5",
     "source-map-support": "^0.5.19",
+    "uuid": "^8.3.2",
     "wav": "^1.0.2"
   },
   "devEngines": {

--- a/src/components/HotKeyConfig/index.tsx
+++ b/src/components/HotKeyConfig/index.tsx
@@ -37,6 +37,7 @@ const HotKeyConfig = () => {
   };
 
   const updateHotKey = () => {
+    if (inputValue === '') return;
     ipcRenderer.send('hotKey:update', inputValue);
     ipcRenderer.on('hotKey:success', () => {
       setHotKey(inputValue);

--- a/src/components/ListItem/index.tsx
+++ b/src/components/ListItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { shell } from 'electron';
 
 import { HiTrash, HiPencil, HiPlay } from 'react-icons/hi';
@@ -14,19 +14,36 @@ const ListItem = ({ recording, recordingManager }: Props) => {
   const [isWavLoading, setIsWavLoading] = useState<boolean>(false);
   const [isTxtLoading, setIsTxtLoading] = useState<boolean>(false);
   const [isDelLoading, setIsDelLoading] = useState<boolean>(false);
+  const [recordingTitle, setRecordingTitle] = useState<string>('');
 
   const styleName =
     'text-indigo-500 hover:text-white hover:bg-indigo-500 active:bg-indigo-600 hover:stroke-current hover:border-transparent';
   const styleNameLoading = 'text-white bg-indigo-600';
 
+  const updateTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newTitle = e.target.value;
+    if (newTitle === recording.title) return;
+    recordingManager.renameRecording(newTitle, recording).catch(console.error);
+  };
+
+  useEffect(() => {
+    setRecordingTitle(recording.title);
+  }, [recording.title]);
+
   return (
     <div className="flex flex-row relative block bg-gray-50 rounded-md p-3 mb-2 hover:bg-indigo-50">
       <div className="flex flex-1 items-center gap-x-3">
-        <div className="flex-1">
-          <p className=" uppercase tracking-wide font-semibold text-xs text-gray-600">
-            Recorded at
-          </p>
-          <p className=" uppercase tracking-wide font-bold text-md text-gray-800">
+        <input
+          type="text"
+          name="recordingTitle"
+          className="flex-grow appearance-none font-semibold text-lg text-gray-800 rounded bg-transparent hover:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:bg-white focus:border-transparent"
+          value={recordingTitle}
+          onChange={(e) => setRecordingTitle(e.target.value)}
+          onBlur={updateTitle}
+        />
+        <div className="w-24 uppercase tracking-wide">
+          <p className="font-semibold text-xs text-gray-500">Recorded at</p>
+          <p className="font-bold text-sm text-gray-700">
             {recording.datetime.toLocaleString('en-US', {
               hour: 'numeric',
               minute: 'numeric',

--- a/src/components/ListItem/index.tsx
+++ b/src/components/ListItem/index.tsx
@@ -22,8 +22,14 @@ const ListItem = ({ recording, recordingManager }: Props) => {
 
   const updateTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newTitle = e.target.value;
-    if (newTitle === recording.title) return;
-    recordingManager.renameRecording(newTitle, recording).catch(console.error);
+    if (newTitle === '' || newTitle === recording.title) {
+      setRecordingTitle(recording.title);
+      return;
+    }
+    recordingManager.renameRecording(newTitle, recording).catch((error) => {
+      console.error(error);
+      setRecordingTitle(recording.title);
+    });
   };
 
   useEffect(() => {

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -17,7 +17,7 @@ const Search = ({ keyword, setKeyword, title, placeholder }: Props) => {
         name="search"
         id="search"
         title={title}
-        className="flex-grow px-4 pr-12 py-2 rounded-md appearance-none border-2 border-indigo-50 bg-white text-gray-700 hover:border-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:border-transparent"
+        className="flex-grow px-4 pr-12 py-2 rounded-md appearance-none border-2 border-indigo-50 bg-white text-gray-800 hover:border-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:border-transparent"
         placeholder={placeholder}
         value={keyword}
         onChange={(e) => setKeyword(e.target.value)}

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -122,8 +122,9 @@ const createMenubar = async (applicationDir: string) => {
     browserWindow: {
       transparent: false,
       alwaysOnTop: false,
-      width: 450,
+      width: 550,
       height: 600,
+      // resizable: false, // Uncomment when building for prod
       webPreferences: {
         nodeIntegration: true,
         enableRemoteModule: true,

--- a/src/recording-manager/Metadata.ts
+++ b/src/recording-manager/Metadata.ts
@@ -1,0 +1,3 @@
+export default class Metadata {
+  constructor(public readonly title: string) {}
+}

--- a/src/recording-manager/Recording.ts
+++ b/src/recording-manager/Recording.ts
@@ -45,6 +45,7 @@ export default class Recording {
   #speechToText: SpeechToText;
 
   constructor(
+    public readonly id: string,
     public readonly title: string,
     public readonly datetime: Date,
     directory: string,

--- a/src/recording-manager/RecordingManager.ts
+++ b/src/recording-manager/RecordingManager.ts
@@ -1,5 +1,13 @@
 import { promisify } from 'util';
-import { createWriteStream, mkdirSync, readdir, rmdir, mkdir, stat } from 'fs';
+import {
+  createWriteStream,
+  mkdirSync,
+  readdir,
+  rmdir,
+  mkdir,
+  stat,
+  rename,
+} from 'fs';
 import path from 'path';
 import { Readable } from 'stream';
 import { v4 as uuidv4 } from 'uuid';
@@ -10,6 +18,7 @@ const readdirAsync = promisify(readdir);
 const rmdirAsync = promisify(rmdir);
 const mkdirAsync = promisify(mkdir);
 const statAsync = promisify(stat);
+const renameAsync = promisify(rename);
 
 export default class RecordingManager {
   #rootDir: string;
@@ -73,5 +82,19 @@ export default class RecordingManager {
     await rmdirAsync(path.join(this.#rootDir, recording.title), {
       recursive: true,
     });
+  }
+
+  async renameRecording(
+    newTitle: string,
+    recording: Recording
+  ): Promise<Recording> {
+    const newDir = path.join(this.#rootDir, newTitle);
+    await renameAsync(path.join(this.#rootDir, recording.title), newDir);
+    return new Recording(
+      newTitle,
+      recording.datetime,
+      newDir,
+      this.#speechToText
+    );
   }
 }

--- a/src/recording-manager/RecordingManager.ts
+++ b/src/recording-manager/RecordingManager.ts
@@ -2,6 +2,7 @@ import { promisify } from 'util';
 import { createWriteStream, mkdirSync, readdir, rmdir, mkdir, stat } from 'fs';
 import path from 'path';
 import { Readable } from 'stream';
+import { v4 as uuidv4 } from 'uuid';
 import Recording from './Recording';
 import SpeechToText from '../speech-to-text';
 
@@ -56,8 +57,7 @@ export default class RecordingManager {
   }
 
   async createRecording(readStream: Readable): Promise<void> {
-    const newFolderName = formatDateForStorage(new Date());
-    const recordingDir = path.join(this.#rootDir, newFolderName);
+    const recordingDir = path.join(this.#rootDir, uuidv4());
 
     await mkdirAsync(recordingDir);
 

--- a/src/recording-manager/RecordingManager.ts
+++ b/src/recording-manager/RecordingManager.ts
@@ -11,12 +11,6 @@ const rmdirAsync = promisify(rmdir);
 const mkdirAsync = promisify(mkdir);
 const statAsync = promisify(stat);
 
-const formatDateForStorage = (datetime: Date) =>
-  datetime.toISOString().replaceAll(':', '_').replaceAll('.', 'dot');
-
-const formatStorageNameForDate = (name: string) =>
-  name.replaceAll('_', ':').replaceAll('dot', '.');
-
 export default class RecordingManager {
   #rootDir: string;
 
@@ -76,9 +70,8 @@ export default class RecordingManager {
   }
 
   async deleteRecording(recording: Recording): Promise<void> {
-    await rmdirAsync(
-      path.join(this.#rootDir, formatDateForStorage(recording.datetime)),
-      { recursive: true }
-    );
+    await rmdirAsync(path.join(this.#rootDir, recording.title), {
+      recursive: true,
+    });
   }
 }

--- a/src/views/MenuBar.tsx
+++ b/src/views/MenuBar.tsx
@@ -38,13 +38,15 @@ const MenuBar = ({
   };
 
   const filterByCurrentInput = (recs: Recording[]) => {
-    let filtered = recs.filter((recording) =>
-      recording.datetime
-        .toLocaleDateString('en-US', { dateStyle: 'full' })
-        .toLowerCase()
-        .includes(input.toLowerCase().trim())
+    const inputString = input.toLowerCase().trim();
+    let filtered = recs.filter(
+      (recording) =>
+        recording.datetime
+          .toLocaleDateString('en-US', { dateStyle: 'full' })
+          .toLowerCase()
+          .includes(inputString) ||
+        recording.title.toLowerCase().includes(inputString)
     );
-    // TODO: Include filter/search for recording name once implemented
     filtered = sortAscending ? filtered.reverse() : filtered;
     return groupRecordingsByDate(filtered);
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,6 +1791,11 @@
   dependencies:
     "@types/jest" "*"
 
+"@types/uuid@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
+  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
+
 "@types/verror@^1.10.3":
   version "1.10.4"
   resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.4.tgz#805c0612b3a0c124cf99f517364142946b74ba3b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12118,10 +12118,10 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
-  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+uuid@^8.3.0, uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Completes `RecordingManager` of #29.

#### Notes
Awaiting UI implementation on the same branch in case further changes to `RecordingManager` is required.

#### Example usage:
```ts
const existingRecording = new Recording(...);
const newTitle = 'My money making idea';
const updatedRecording = recordingManager.renameRecording(newTitle, existingRecording);
console.log(updatedRecording.title); // "My money making idea"
```
