### PR TITLE
Enable RecordingManager to handle imports

### DIFF
--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -6,6 +6,7 @@ export type Props = {
   onClick: () => void;
   isLoading?: boolean;
   children?: React.ReactNode;
+  title?: string;
   addStyleName?: string;
   addStyleNameLoading?: string;
 };
@@ -14,6 +15,7 @@ const IconButton = ({
   onClick,
   isLoading = false,
   children,
+  title,
   addStyleName = '',
   addStyleNameLoading = '',
 }: Props) => {
@@ -30,6 +32,7 @@ const IconButton = ({
     <button
       type="button"
       disabled={isLoading}
+      title={title}
       onClick={onClick}
       className={styleName}
     >

--- a/src/recording-manager/Recording.ts
+++ b/src/recording-manager/Recording.ts
@@ -1,39 +1,11 @@
 import path from 'path';
 import { writeFile } from 'fs';
 import { promisify } from 'util';
-import { spawn } from 'child_process';
-import ffmpegPath from 'ffmpeg-static';
 import { exists } from '../utils';
 import SpeechToText from '../speech-to-text';
+import { fileToWav as webmToWav } from './converter';
 
 const writeFileAsync = promisify(writeFile);
-
-const webmToWav = async (
-  webmFileDir: string,
-  destDir: string,
-  wavFileName: string
-): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    const ffmpeg = spawn(ffmpegPath, [
-      // eslint-disable-next-line prettier/prettier
-      '-i', webmFileDir,
-      // eslint-disable-next-line prettier/prettier
-      '-ar', '16000',
-      // eslint-disable-next-line prettier/prettier
-      '-y', path.join(destDir, `${wavFileName}.wav`),
-    ]);
-    let output = '';
-    ffmpeg.stderr.on('data', (chunk) => {
-      output += chunk;
-    });
-    ffmpeg.on('exit', (code) => {
-      if (code) {
-        return reject(new Error(output));
-      }
-      return resolve();
-    });
-  });
-};
 
 export default class Recording {
   static defaultAudioName = 'audio';

--- a/src/recording-manager/RecordingManager.ts
+++ b/src/recording-manager/RecordingManager.ts
@@ -16,6 +16,7 @@ import { v4 as uuidv4 } from 'uuid';
 import Recording from './Recording';
 import Metadata from './Metadata';
 import SpeechToText from '../speech-to-text';
+import { fileToWav } from './converter';
 
 const readdirAsync = promisify(readdir);
 const rmdirAsync = promisify(rmdir);
@@ -24,6 +25,23 @@ const statAsync = promisify(stat);
 const writeFileAsync = promisify(writeFile);
 const appendFileAsync = promisify(appendFile);
 const readFileAsync = promisify(readFile);
+
+const writeStreamToDir = async (
+  dir: string,
+  readStream: Readable
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const writeStream = createWriteStream(dir);
+    readStream.pipe(writeStream);
+    readStream.on('end', () => {
+      return resolve();
+    });
+    readStream.on('error', (err) => {
+      return reject(err);
+    });
+  });
+};
+
 export default class RecordingManager {
   #rootDir: string;
 
@@ -32,6 +50,8 @@ export default class RecordingManager {
   #metadataFileName = '.metadata';
 
   #defaultRecordingName = 'Untitled Recording';
+
+  #defaultImportName = 'Untitled Import';
 
   constructor(applicationDir: string) {
     this.#rootDir = path.join(applicationDir, 'recordings');
@@ -82,18 +102,36 @@ export default class RecordingManager {
       JSON.stringify(new Metadata(this.#defaultRecordingName))
     );
 
-    return new Promise((resolve, reject) => {
-      const writeStream = createWriteStream(
-        path.join(recordingDir, `${Recording.defaultAudioName}.webm`)
+    return writeStreamToDir(
+      path.join(recordingDir, `${Recording.defaultAudioName}.webm`),
+      readStream
+    );
+  }
+
+  async importMediaAsRecording(readStream: Readable): Promise<void> {
+    const recordingDir = path.join(this.#rootDir, uuidv4());
+
+    try {
+      await mkdirAsync(recordingDir);
+      await appendFileAsync(
+        path.join(recordingDir, this.#metadataFileName),
+        JSON.stringify(new Metadata(this.#defaultImportName))
       );
-      readStream.pipe(writeStream);
-      readStream.on('end', () => {
-        return resolve();
+      await writeStreamToDir(
+        path.join(recordingDir, this.#defaultImportName),
+        readStream
+      );
+      await fileToWav(
+        path.join(recordingDir, this.#defaultImportName),
+        recordingDir,
+        Recording.defaultAudioName
+      );
+    } catch (err) {
+      await rmdirAsync(recordingDir, {
+        recursive: true,
       });
-      readStream.on('error', (err) => {
-        return reject(err);
-      });
-    });
+      throw err;
+    }
   }
 
   async deleteRecording(recording: Recording): Promise<void> {

--- a/src/recording-manager/converter.ts
+++ b/src/recording-manager/converter.ts
@@ -1,0 +1,31 @@
+import { spawn } from 'child_process';
+import ffmpegPath from 'ffmpeg-static';
+import path from 'path';
+
+// eslint-disable-next-line import/prefer-default-export
+export const fileToWav = async (
+  srcFileDir: string,
+  destDir: string,
+  wavFileName: string
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const ffmpeg = spawn(ffmpegPath, [
+      // eslint-disable-next-line prettier/prettier
+        '-i', srcFileDir,
+      // eslint-disable-next-line prettier/prettier
+        '-ar', '16000',
+      // eslint-disable-next-line prettier/prettier
+        '-y', path.join(destDir, `${wavFileName}.wav`),
+    ]);
+    let output = '';
+    ffmpeg.stderr.on('data', (chunk) => {
+      output += chunk;
+    });
+    ffmpeg.on('exit', (code) => {
+      if (code) {
+        return reject(new Error(output));
+      }
+      return resolve();
+    });
+  });
+};

--- a/src/recording-manager/converter.ts
+++ b/src/recording-manager/converter.ts
@@ -11,11 +11,17 @@ export const fileToWav = async (
   return new Promise((resolve, reject) => {
     const ffmpeg = spawn(ffmpegPath, [
       // eslint-disable-next-line prettier/prettier
-        '-i', srcFileDir,
+      '-i', srcFileDir,
+      '-vn',
       // eslint-disable-next-line prettier/prettier
-        '-ar', '16000',
+      '-ac', '1',
       // eslint-disable-next-line prettier/prettier
-        '-y', path.join(destDir, `${wavFileName}.wav`),
+      '-ar', '16000',
+      // eslint-disable-next-line prettier/prettier
+      '-acodec', 'pcm_s16le',
+      // eslint-disable-next-line prettier/prettier
+      '-y',
+      path.join(destDir, `${wavFileName}.wav`),
     ]);
     let output = '';
     ffmpeg.stderr.on('data', (chunk) => {

--- a/src/views/MenuBar.tsx
+++ b/src/views/MenuBar.tsx
@@ -6,6 +6,7 @@ import {
   HiOutlineCog,
   HiSortAscending,
   HiSortDescending,
+  HiUpload,
 } from 'react-icons/hi';
 import { Recording, RecordingManager } from '../recording-manager';
 
@@ -22,9 +23,13 @@ const MenuBar = ({
 }) => {
   const [recordings, setRecordings] = useState<Record<string, Recording[]>>({});
   const [sortAscending, setSortAscending] = useState<boolean>(false);
+  const [selectedFile, setSelectedFile] = useState<File | undefined>();
   const [input, setInput] = useState<string>('');
 
   const history = useHistory();
+  const fileRef = React.useRef<HTMLInputElement>(null);
+  const styleName =
+    'text-indigo-500 bg-indigo-50 hover:text-white active:text-white hover:bg-indigo-500 active:bg-indigo-600 focus:outline-none';
 
   const groupRecordingsByDate = (recs: Recording[]) => {
     return recs.reduce((groups, rec) => {
@@ -47,6 +52,17 @@ const MenuBar = ({
     // TODO: Include filter/search for recording name once implemented
     filtered = sortAscending ? filtered.reverse() : filtered;
     return groupRecordingsByDate(filtered);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+    console.log(e.target.files);
+    if (e.target.files.length > 0) setSelectedFile(e.target.files[0]);
+  };
+
+  const uploadFile = () => {
+    if (!fileRef.current) return;
+    fileRef.current.click();
   };
 
   useEffect(() => {
@@ -86,18 +102,35 @@ const MenuBar = ({
         handleClick={() => history.push('/settings')}
       />
       <div className="flex flex-row mt-4 gap-x-3 items-center">
+        <IconButton
+          onClick={() => setSortAscending(!sortAscending)}
+          addStyleName={styleName}
+        >
+          {sortAscending ? <HiSortAscending /> : <HiSortDescending />}
+        </IconButton>
         <Search
           keyword={input}
           setKeyword={setInput}
           title="Search for a recording"
           placeholder="Search"
         />
-        <IconButton
-          onClick={() => setSortAscending(!sortAscending)}
-          addStyleName="text-indigo-500 bg-indigo-50 hover:text-white active:text-white hover:bg-indigo-500 active:bg-indigo-600 focus:outline-none"
-        >
-          {sortAscending ? <HiSortAscending /> : <HiSortDescending />}
-        </IconButton>
+        <div>
+          <input
+            type="file"
+            name="file"
+            accept="audio/*,video/*"
+            ref={fileRef}
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+          />
+          <IconButton
+            onClick={uploadFile}
+            addStyleName={styleName}
+            title="Upload video/audio file for transcribing"
+          >
+            <HiUpload />
+          </IconButton>
+        </div>
       </div>
       {Object.entries(recordings).map(([k, v]) => (
         <React.Fragment key={k}>

--- a/src/views/MenuBar.tsx
+++ b/src/views/MenuBar.tsx
@@ -8,6 +8,7 @@ import {
   HiSortDescending,
   HiUpload,
 } from 'react-icons/hi';
+import { createReadStream } from 'fs';
 import { Recording, RecordingManager } from '../recording-manager';
 
 import Header from '../components/Header';
@@ -23,7 +24,6 @@ const MenuBar = ({
 }) => {
   const [recordings, setRecordings] = useState<Record<string, Recording[]>>({});
   const [sortAscending, setSortAscending] = useState<boolean>(false);
-  const [selectedFile, setSelectedFile] = useState<File | undefined>();
   const [input, setInput] = useState<string>('');
 
   const history = useHistory();
@@ -56,10 +56,14 @@ const MenuBar = ({
     return groupRecordingsByDate(filtered);
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!e.target.files) return;
-    console.log(e.target.files);
-    if (e.target.files.length > 0) setSelectedFile(e.target.files[0]);
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = e.target;
+    if (!files) return;
+    if (files.length > 0 && recordingManager) {
+      const media = createReadStream(files[0].path);
+      await recordingManager.importMediaAsRecording(media).catch(console.error);
+    }
+    e.target.value = '';
   };
 
   const uploadFile = () => {
@@ -120,9 +124,9 @@ const MenuBar = ({
           <input
             type="file"
             name="file"
+            className="hidden"
             accept="audio/*,video/*"
             ref={fileRef}
-            style={{ display: 'none' }}
             onChange={handleFileChange}
           />
           <IconButton


### PR DESCRIPTION
Implemented FFMpeg conversion of #28.

### Notes:
Awaiting UI implementation on the same branch in case further changes to RecordingManager is required.

### Example Usage:
```ts
// Process imported media as a Readable (readstream) without writing to file system.
const readStream = ...;
try {
  await RecordingManager.importMediaAsRecording(readStream);
} catch (err) {
  // Process error.
}
```